### PR TITLE
16 investigate controlling of themes with an extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # Sinister-Six-Chrome-Extension
 This is our awesome group 6 repository for our CS 3250 assignments! We can update the name and description once we settle in.
 
-This is my edit to test pull requests.
+Current progress:
+management permission allows us to see currently installed themes!
+
+Current roadblocks:
+Only active themes are left installed.... Not sure how we'll get around this. Maybe we can use storage permissions to store themes in the extension and switch them from there

--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
 # Sinister-Six-Chrome-Extension
 This is our awesome group 6 repository for our CS 3250 assignments! We can update the name and description once we settle in.
 
-Current progress:
-management permission allows us to see currently installed themes!
-
-Current roadblocks:
-Only active themes are left installed.... Not sure how we'll get around this. Maybe we can use storage permissions to store themes in the extension and switch them from there
+we need to decide on a name!!

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
-    "name": "test!!",
-    "description": "this is a very testy extension",
-    "version": "99.9",
+    "name": "themanager",
+    "description": "Themanager manages your chrome themes so you can access them quickly and easily",
+    "version": "0.01",
     "manifest_version": 3,
     "action":{
         "default_popup": "popup.html",
@@ -9,7 +9,6 @@
     },
    "permissions": [
     "management",
-    "theme",
     "storage"
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,8 @@
     "action":{
         "default_popup": "popup.html",
         "default_icon": "icon.png"
-    }
+    },
+   "permissions": [
+    "management"
+  ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-    "name": "test!",
+    "name": "test!!",
     "description": "this is a very testy extension",
     "version": "99.9",
     "manifest_version": 3,
@@ -8,6 +8,8 @@
         "default_icon": "icon.png"
     },
    "permissions": [
-    "management"
+    "management",
+    "theme",
+    "storage"
   ]
 }

--- a/popup.html
+++ b/popup.html
@@ -8,6 +8,7 @@
     <p id="text2">Hi</p>
 
     <button id="myButton">Detect Theme</button>
+    <button id="link">go to uninstalled theme</button>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/popup.html
+++ b/popup.html
@@ -5,9 +5,9 @@
   </head>
   <body>
     <h1 id="title">Hello</h1>
-    <p id="text2">Hi</p>
+    <p id="text2">Uninstalled theme links are currently hardcoded</p>
 
-    <button id="myButton">Detect Theme</button>
+    <button id="myButton">Toggle Theme</button>
     <button id="link">go to uninstalled theme</button>
     <script src="popup.js"></script>
   </body>

--- a/popup.html
+++ b/popup.html
@@ -8,7 +8,6 @@
     <p id="text2">Hi</p>
 
     <button id="myButton">Detect Theme</button>
-
     <script src="popup.js"></script>
   </body>
 </html>

--- a/popup.html
+++ b/popup.html
@@ -1,5 +1,14 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>My Extension</title>
+  </head>
   <body>
-    <h1>Hey whats up whats going on</h1>
+    <h1 id="title">Hello</h1>
+
+    <button id="myButton">Change text</button>
+
+    <script src="popup.js"></script>
   </body>
 </html>

--- a/popup.html
+++ b/popup.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
     <title>My Extension</title>
   </head>
   <body>
     <h1 id="title">Hello</h1>
+    <p id="text2">Hi</p>
 
-    <button id="myButton">Change text</button>
+    <button id="myButton">Detect Theme</button>
 
     <script src="popup.js"></script>
   </body>

--- a/popup.js
+++ b/popup.js
@@ -1,8 +1,11 @@
 document.addEventListener("DOMContentLoaded", () => {
   const button = document.getElementById("myButton");
-  const button2 = document.getElementById("button2");
+  const button2 = document.getElementById("link");
   const title = document.getElementById("title");
   const text = document.getElementById("text2");
+
+  const themeLink =
+    "https://chromewebstore.google.com/detail/pikmin-theme/bpmkhflicgoklmheccmojdbipcbmhcjg?utm_source=ext_app_menu";
 
   if (!button || !title) {
     console.error("Element not found");
@@ -11,10 +14,13 @@ document.addEventListener("DOMContentLoaded", () => {
 
   button.addEventListener("click", async () => {
     const extensions = await chrome.management.getAll();
+
     var disabledExtension = null;
     for (let i = 0; i < extensions.length; i++) {
       if (extensions[i].type === "theme" && !extensions[i].enabled) {
         disabledExtension = extensions[i];
+      } else if (extensions[i].type === "theme") {
+        console.log(extensions[i].name);
       }
     }
 
@@ -42,14 +48,29 @@ document.addEventListener("DOMContentLoaded", () => {
         }
       });
       disabledExtension = null;
+      for (let i = 0; i < extensions.length; i++) {
+        if (extensions[i].type === "theme" && !extensions[i].enabled) {
+          disabledExtension2 = extensions[0];
+          console.log(extensions[0]);
+        }
+      }
     }
 
     title.textContent = enabledExtension
       ? enabledExtension.name
       : "No enabled themes found";
 
-    text.textContent = enabledExtension
+    text.textContent = disabledExtension
       ? disabledExtension.name
       : "No disabled themes found";
+  });
+  button2.addEventListener("click", async () => {
+    window.open(themeLink, "_blank", "noopener");
+
+    for (let i = 0; i < extensions.length; i++) {
+      if (extensions[i].type === "theme" && !extensions[i].enabled) {
+        disabledExtension = extensions[i];
+      }
+    }
   });
 });

--- a/popup.js
+++ b/popup.js
@@ -1,6 +1,7 @@
 document.addEventListener("DOMContentLoaded", () => {
   const button = document.getElementById("myButton");
   const title = document.getElementById("title");
+  const text = document.getElementById("text2");
 
   if (!button || !title) {
     console.error("Element not found");
@@ -11,10 +12,36 @@ document.addEventListener("DOMContentLoaded", () => {
     const extensions = await chrome.management.getAll();
 
     // Example: find the first enabled extension
-    const enabledExtension = extensions.find(ext => ext.type === "theme" && ext.enabled);
+    const enabledExtension = extensions.find(
+      (ext) => ext.type === "theme" && ext.enabled,
+    );
+
+    const disabledExtension = extensions.find(
+      (ext) => ext.type === "theme" && ext.disabled,
+    );
 
     title.textContent = enabledExtension
       ? enabledExtension.name
-      : "No enabled extensions found";
+      : "No enabled themes found";
+
+    text2.textContent = enabledExtension
+      ? enabledExtension.version
+      : "No disabled themes found";
+
+    chrome.theme.update(
+      {
+        colors: {
+          frame: [255, 0, 0], // RGB for red
+          toolbar: [255, 200, 200], // optional
+          tab_text: [255, 255, 255],
+        },
+        images: {}, // optional
+        tints: {}, // optional
+        properties: {}, // optional
+      },
+      () => {
+        console.log("Theme applied!");
+      },
+    );
   });
 });

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,20 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const button = document.getElementById("myButton");
+  const title = document.getElementById("title");
+
+  if (!button || !title) {
+    console.error("Element not found");
+    return;
+  }
+
+  button.addEventListener("click", async () => {
+    const extensions = await chrome.management.getAll();
+
+    // Example: find the first enabled extension
+    const enabledExtension = extensions.find(ext => ext.type === "theme" && ext.enabled);
+
+    title.textContent = enabledExtension
+      ? enabledExtension.name
+      : "No enabled extensions found";
+  });
+});

--- a/popup.js
+++ b/popup.js
@@ -29,16 +29,18 @@ document.addEventListener("DOMContentLoaded", () => {
     );
 
     if (disabledExtension == null) {
+      //disable theme if there is currently a theme enabled
       disabledExtension = enabledExtension;
       chrome.management.setEnabled(enabledExtension.id, false, () => {
         if (chrome.runtime.lastError) {
           console.error(chrome.runtime.lastError);
         } else {
-          console.log("Extension enabled!");
+          console.log("Extension disabled!");
         }
       });
       enabledExtension = null;
     } else {
+      //enable theme if the installed theme is inactive
       enabledExtension = disabledExtension;
       chrome.management.setEnabled(disabledExtension.id, true, () => {
         if (chrome.runtime.lastError) {
@@ -48,29 +50,14 @@ document.addEventListener("DOMContentLoaded", () => {
         }
       });
       disabledExtension = null;
-      for (let i = 0; i < extensions.length; i++) {
-        if (extensions[i].type === "theme" && !extensions[i].enabled) {
-          disabledExtension2 = extensions[0];
-          console.log(extensions[0]);
-        }
-      }
     }
 
-    title.textContent = enabledExtension
+
+    title.textContent = enabledExtension 
       ? enabledExtension.name
       : "No enabled themes found";
-
-    text.textContent = disabledExtension
-      ? disabledExtension.name
-      : "No disabled themes found";
   });
   button2.addEventListener("click", async () => {
     window.open(themeLink, "_blank", "noopener");
-
-    for (let i = 0; i < extensions.length; i++) {
-      if (extensions[i].type === "theme" && !extensions[i].enabled) {
-        disabledExtension = extensions[i];
-      }
-    }
   });
 });

--- a/popup.js
+++ b/popup.js
@@ -1,5 +1,6 @@
 document.addEventListener("DOMContentLoaded", () => {
   const button = document.getElementById("myButton");
+  const button2 = document.getElementById("button2");
   const title = document.getElementById("title");
   const text = document.getElementById("text2");
 
@@ -10,38 +11,45 @@ document.addEventListener("DOMContentLoaded", () => {
 
   button.addEventListener("click", async () => {
     const extensions = await chrome.management.getAll();
+    var disabledExtension = null;
+    for (let i = 0; i < extensions.length; i++) {
+      if (extensions[i].type === "theme" && !extensions[i].enabled) {
+        disabledExtension = extensions[i];
+      }
+    }
 
-    // Example: find the first enabled extension
-    const enabledExtension = extensions.find(
+    var enabledExtension = extensions.find(
       (ext) => ext.type === "theme" && ext.enabled,
     );
 
-    const disabledExtension = extensions.find(
-      (ext) => ext.type === "theme" && ext.disabled,
-    );
+    if (disabledExtension == null) {
+      disabledExtension = enabledExtension;
+      chrome.management.setEnabled(enabledExtension.id, false, () => {
+        if (chrome.runtime.lastError) {
+          console.error(chrome.runtime.lastError);
+        } else {
+          console.log("Extension enabled!");
+        }
+      });
+      enabledExtension = null;
+    } else {
+      enabledExtension = disabledExtension;
+      chrome.management.setEnabled(disabledExtension.id, true, () => {
+        if (chrome.runtime.lastError) {
+          console.error(chrome.runtime.lastError);
+        } else {
+          console.log("Extension enabled!");
+        }
+      });
+      disabledExtension = null;
+    }
 
     title.textContent = enabledExtension
       ? enabledExtension.name
       : "No enabled themes found";
 
-    text2.textContent = enabledExtension
-      ? enabledExtension.version
+    text.textContent = enabledExtension
+      ? disabledExtension.name
       : "No disabled themes found";
-
-    chrome.theme.update(
-      {
-        colors: {
-          frame: [255, 0, 0], // RGB for red
-          toolbar: [255, 200, 200], // optional
-          tab_text: [255, 255, 255],
-        },
-        images: {}, // optional
-        tints: {}, // optional
-        properties: {}, // optional
-      },
-      () => {
-        console.log("Theme applied!");
-      },
-    );
   });
 });


### PR DESCRIPTION
## This PR introduces the following changes:

- Adds popup.js 
     - handles theme toggle logic
     - handles navigation to linked themes

- Adds two buttons to popup.html 

## Testing

1. ensure you have a theme from the chrome store active on chrome. 
2. in the directory of the repository, run `git checkout develop` then `git fetch origin`, and finally `git pull`
3. run `git checkout 16-investigate-controlling-of-themes-with-an-extension`
4. reload the unpacked extension if you need to, otherwise skip this step
5. Click the extension and verify the buttons pop up and function as they did in the demo video.

## Notes

The code is a little messy right now, I can work on streamlining it, especially as we narrow down our approach on retrieving extension links from users

The link for uninstalled theme is currently hardcoded