### PR TITLE
38 add remove theme from collection functionality

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -202,6 +202,27 @@
           box-shadow 0.15s;
       }
 
+      .delete-button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 14px;
+        width: 100%;
+        padding: 10px;
+        font-size: 13px;
+        font-family: inherit;
+        font-weight: 600;
+        color: #fff;
+        background: linear-gradient(135deg, #f94316, #ff0000);
+        border: none;
+        border-radius: 10px;
+        margin-top: 8px;
+        cursor: pointer;
+        transition:
+          transform 0.15s,
+          box-shadow 0.15s;
+      }
+
       .button-row {
         display: flex;
         gap: 8px;
@@ -219,6 +240,41 @@
 
       .store-link:active {
         transform: translateY(0);
+      }
+
+      .modal {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 999;
+      }
+
+      .modal-backdrop {
+        position: absolute;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.4);
+      }
+
+      .modal-content {
+        position: relative;
+        background: white;
+        padding: 18px;
+        border-radius: 12px;
+        width: 85%;
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+        text-align: center;
+      }
+
+      .modal-buttons {
+        display: flex;
+        gap: 8px;
+        margin-top: 14px;
+      }
+
+      .modal-buttons button {
+        flex: 1;
       }
 
       [hidden] {
@@ -255,6 +311,21 @@
         <div class="button-row">
           <button id="toggle" class="store-link">Toggle Theme</button>
           <button id="add" class="store-link" hidden>Add Current Theme</button>
+          <button id="del" class="store-link" hidden>
+            Remove Current Theme
+          </button>
+        </div>
+      </div>
+      <button id="clearAll" class="delete-button">Clear Collection</button>
+    </div>
+
+    <div id="confirmModal" class="modal" hidden>
+      <div class="modal-backdrop"></div>
+      <div class="modal-content">
+        <p id="confirmMessage"></p>
+        <div class="modal-buttons">
+          <button id="confirmYes" class="store-link">Yes</button>
+          <button id="confirmNo" class="store-link">Cancel</button>
         </div>
       </div>
     </div>

--- a/popup.js
+++ b/popup.js
@@ -347,14 +347,11 @@ async function init() {
     )
       return;
 
-    const state = await loadState();
-    await chrome.storage.local.clear();
+    await chrome.storage.local.remove('links');
     for (let i = dropdown.length; i >= 0; i--) {
       dropdown.remove(i);
     }
-    saveState(state);
-    console.log(state);
-    renderCurrentThemeUI(state);
+    renderCurrentThemeUI(await loadState());
   });
 }
 

--- a/popup.js
+++ b/popup.js
@@ -9,6 +9,7 @@ import {
   getCurrentTheme,
   makeLink,
 } from './src/themes.js';
+import { showConfirm } from './src/ui.js';
 
 const DEFAULT_ID = 'default';
 const STORAGE_KEY = 'themeState';
@@ -18,8 +19,10 @@ const nameEl = document.getElementById('currentThemeName');
 const indicatorEl = document.getElementById('themeIndicator');
 const noticeEl = document.getElementById('noticeArea');
 const addBtn = document.getElementById('add');
+const delBtn = document.getElementById('del');
 const toggleBtn = document.getElementById('toggle');
 const infoTip = document.getElementById('info');
+const clearAllBtn = document.getElementById('clearAll');
 
 /**
  * Renders the current theme state into the popup UI.
@@ -27,6 +30,8 @@ const infoTip = document.getElementById('info');
  */
 function renderCurrentThemeUI(state) {
   nameEl.textContent = state.currentThemeName;
+
+  console.log(state);
 
   if (state.isDefault) {
     indicatorEl.textContent = 'Default';
@@ -46,8 +51,15 @@ function renderCurrentThemeUI(state) {
   } else if (state.currentThemeId !== DEFAULT_ID) {
     dropdown.value = DEFAULT_ID; // fallback to default
     hideAddTheme(false);
-  }else {
+    console.log(dropdown.value);
+  } else {
     dropdown.value = DEFAULT_ID;
+  }
+
+  if (dropdown.length == 0) {
+    dropdown.disabled = true;
+  } else {
+    dropdown.disabled = false;
   }
   hideNotice();
 }
@@ -120,6 +132,7 @@ function extractName(link) {
 function hideAddTheme(isThemeInCollection) {
   infoTip.hidden = isThemeInCollection;
   addBtn.hidden = isThemeInCollection;
+  delBtn.hidden = !isThemeInCollection;
 }
 
 /**
@@ -184,7 +197,6 @@ async function handleDropdownChange() {
           `<a id="reinstallLink">Reinstall it from the Web Store</a>.`,
         'info'
       );
-    
     } else {
       showNotice(`Failed to change theme: ${err.message}`);
     }
@@ -288,7 +300,6 @@ async function init() {
 
     await saveState(state);
     renderCurrentThemeUI(state);
-
   } catch (err) {
     console.error('Popup init failed:', err);
     showNotice(`Error: ${err.message}`);
@@ -301,7 +312,6 @@ async function init() {
     const result = await chrome.storage.local.get(['links']);
     const themeLinks = result.links || [];
     const theme = await getInstalledThemes();
-    console.log(makeLink(theme[0].name, theme[0].id));
     const newLink = makeLink(theme[0].name, theme[0].id);
 
     if (!themeLinks.includes(newLink)) {
@@ -309,8 +319,42 @@ async function init() {
       await chrome.storage.local.set({ links: themeLinks });
       populateDropdown([newLink]);
       dropdown.value = newLink;
-      hideAddTheme(true);
+      renderCurrentThemeUI(await loadState());
     }
+  });
+
+  delBtn.addEventListener('click', async () => {
+    if (
+      !(await showConfirm(
+        'Are you sure you want to remove this theme from your collection?'
+      ))
+    )
+      return;
+
+    const result = await chrome.storage.local.get(['links']);
+    const updatedLinks =
+      result.links.filter((link) => link !== dropdown.value) || [];
+    await chrome.storage.local.set({ links: updatedLinks });
+    dropdown.remove(dropdown.selectedIndex);
+    renderCurrentThemeUI(await loadState());
+  });
+
+  clearAllBtn.addEventListener('click', async () => {
+    if (
+      !(await showConfirm(
+        'This will remove all themes from your collection. Are you sure you want to continue?'
+      ))
+    )
+      return;
+
+    const state = await loadState();
+    await chrome.storage.local.clear();
+    for (let i = dropdown.length; i >= 0; i--) {
+      dropdown.remove(i);
+    }
+    saveState(state);
+    console.log(state);
+    renderCurrentThemeUI(state);
   });
 }
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,0 +1,38 @@
+/**
+ * Displays a the confirm card
+ *
+ * @description Displays a confirm card with a configurable message and two buttons for user input
+ * @returns {Promise<void>}
+ *
+ * @example
+ * await showConfirm('This will remove all themes from your collection. Are you sure you want to continue?')
+ */
+export function showConfirm(message) {
+  return new Promise((resolve) => {
+    const modal = document.getElementById('confirmModal');
+    const msg = document.getElementById('confirmMessage');
+    const yesBtn = document.getElementById('confirmYes');
+    const noBtn = document.getElementById('confirmNo');
+
+    msg.textContent = message;
+    modal.hidden = false;
+
+    function cleanup(result) {
+      modal.hidden = true;
+      yesBtn.removeEventListener('click', yesHandler);
+      noBtn.removeEventListener('click', noHandler);
+      resolve(result);
+    }
+
+    function yesHandler() {
+      cleanup(true);
+    }
+
+    function noHandler() {
+      cleanup(false);
+    }
+
+    yesBtn.addEventListener('click', yesHandler);
+    noBtn.addEventListener('click', noHandler);
+  });
+}


### PR DESCRIPTION
## This PR Introduces the Following Changes:

- Adds "Remove Current Theme" button, which removes the currently active theme from the user's collection.
- Adds "Clear Collection" button, which removes every theme from the user's collection.
- Creates ui.js for UI related functions. Some functions from popup.js should be moved there during code cleanup
- Adds confirmation popup. Can be used for anything, but right now it is only used for removal actions
- The dropdown is now disabled whenever the user's collection is empty

## Steps to Review:

1. Ensure you are on the develop branch
2. run git fetch origin
3. run git pull
4. run git checkout 38-add-remove-theme-from-collection-functionality
5. Refresh the extension
6. If you don't already have multiple themes in your collection, add a few.
7. Ensure that the add button is displayed when the active theme is not in your collection
8. Ensure that the remove button is displayed when the active theme IS in your collection
9. Test the remove button and ensure the confirmation popup appears
10. Ensure the active theme is removed from the collection if you choose yes, or nothing is done if you choose cancel.
11. Test the clear collection button and ensure it behaves similarly to the remove button
12. Ensure all themes are removed from the collection if yes is selected on the confirmation popup for the clear collection button.