### PR TITLE
Refactor popup logic into testable module and add Jest tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,15 +3,12 @@ import globals from "globals";
 import prettier from "eslint-config-prettier";
 
 export default [
-  // Ignored paths
   {
     ignores: ["node_modules/", "dist/", "build/", "coverage/", "docs/api/"],
   },
 
-  // Base recommended rules for all JS files
   eslintJs.configs.recommended,
 
-  // Global settings for extension/browser code
   {
     files: ["**/*.{js,mjs,cjs}"],
     languageOptions: {
@@ -24,7 +21,6 @@ export default [
     },
   },
 
-  // Node environment for tooling scripts (so `process` is defined)
   {
     files: ["build.js"],
     languageOptions: {
@@ -34,6 +30,14 @@ export default [
     },
   },
 
-  // Prettier must be last to override formatting rules
+  {
+    files: ["**/*.test.js"],
+    languageOptions: {
+      globals: {
+        ...globals.jest,
+      },
+    },
+  },
+
   prettier,
 ];

--- a/popup.js
+++ b/popup.js
@@ -10,8 +10,12 @@ import {
   makeLink,
 } from './src/themes.js';
 import { showConfirm } from './src/ui.js';
+import {
+  extractName,
+  detectCurrentState,
+  DEFAULT_ID,
+} from './src/popupLogic.js';
 
-const DEFAULT_ID = 'default';
 const STORAGE_KEY = 'themeState';
 
 const dropdown = document.getElementById('themeDropdown');
@@ -103,26 +107,12 @@ function hideNotice() {
  * @param {Array<string>} themes
  */
 function populateDropdown(themes) {
-  // Remove any previously added theme options (keep the default option)
   for (const theme of themes) {
     const option = document.createElement('option');
     option.value = theme;
     option.textContent = extractName(theme);
     dropdown.appendChild(option);
   }
-}
-
-/**
- * Extracts extension name from the link
- * @param {Array<string>} themes
- */
-function extractName(link) {
-  return link
-    .split('/detail/')[1]
-    .split('/')[0]
-    .split('-')
-    .map((w) => w[0].toUpperCase() + w.slice(1))
-    .join(' ');
 }
 
 /**
@@ -133,27 +123,6 @@ function hideAddTheme(isThemeInCollection) {
   infoTip.hidden = isThemeInCollection;
   addBtn.hidden = isThemeInCollection;
   delBtn.hidden = !isThemeInCollection;
-}
-
-/**
- * Determines the current theme state from installed themes list.
- * @param {Array<{ id: string, name: string, enabled: boolean }>} themes
- * @returns {{ currentThemeId: string, currentThemeName: string, isDefault: boolean }}
- */
-function detectCurrentState(themes) {
-  const activeTheme = themes.find((t) => t.enabled);
-  if (activeTheme) {
-    return {
-      currentThemeId: activeTheme.id,
-      currentThemeName: activeTheme.name,
-      isDefault: false,
-    };
-  }
-  return {
-    currentThemeId: DEFAULT_ID,
-    currentThemeName: 'Default Theme',
-    isDefault: true,
-  };
 }
 
 /**
@@ -201,7 +170,6 @@ async function handleDropdownChange() {
       showNotice(`Failed to change theme: ${err.message}`);
     }
 
-    // Revert dropdown to previous selection
     dropdown.value = previousValue;
   }
 }
@@ -212,7 +180,6 @@ async function handleDropdownChange() {
 async function handleThemeToggle() {
   const themes = await getInstalledThemes();
 
-  // Find currently enabled theme
   const activeTheme = themes.find((t) => t.enabled);
   const inactiveTheme = themes.find((t) => !t.enabled);
 
@@ -220,7 +187,6 @@ async function handleThemeToggle() {
     let newState;
 
     if (activeTheme) {
-      // Revert to default
       chrome.management.setEnabled(activeTheme.id, false, () => {
         if (chrome.runtime.lastError) {
           console.error(chrome.runtime.lastError);
@@ -228,7 +194,7 @@ async function handleThemeToggle() {
           console.log('Extension disabled!');
         }
       });
-      revertTheme(); // update internal state
+      revertTheme();
 
       newState = {
         currentThemeId: DEFAULT_ID,
@@ -243,7 +209,7 @@ async function handleThemeToggle() {
           console.log('Extension disabled!');
         }
       });
-      applyTheme(inactiveTheme.id); // update internal state
+      applyTheme(inactiveTheme.id);
 
       newState = {
         currentThemeId: inactiveTheme.id,
@@ -251,7 +217,6 @@ async function handleThemeToggle() {
         isDefault: false,
       };
     } else {
-      // No themes installed
       return;
     }
 
@@ -269,12 +234,9 @@ async function handleThemeToggle() {
 async function init() {
   try {
     const themes = await getInstalledThemes();
-    //populateDropdown(themes);
 
-    // Detect actual Chrome state (source of truth)
     const detectedState = detectCurrentState(themes);
 
-    // Load saved state for name display, but trust Chrome for which is active
     const savedState = await loadState();
 
     const state = {
@@ -291,7 +253,6 @@ async function init() {
 
     populateDropdown(themeLinks);
 
-    // Sync internal state module
     if (state.isDefault) {
       revertTheme();
     } else {
@@ -328,8 +289,9 @@ async function init() {
       !(await showConfirm(
         'Are you sure you want to remove this theme from your collection?'
       ))
-    )
+    ) {
       return;
+    }
 
     const result = await chrome.storage.local.get(['links']);
     const updatedLinks =
@@ -344,8 +306,9 @@ async function init() {
       !(await showConfirm(
         'This will remove all themes from your collection. Are you sure you want to continue?'
       ))
-    )
+    ) {
       return;
+    }
 
     await chrome.storage.local.remove('links');
     for (let i = dropdown.length; i >= 0; i--) {

--- a/src/popupLogic.js
+++ b/src/popupLogic.js
@@ -1,0 +1,28 @@
+// src/popupLogic.js
+
+export const DEFAULT_ID = 'default';
+
+export function extractName(link) {
+  return link
+    .split('/detail/')[1]
+    .split('/')[0]
+    .split('-')
+    .map((w) => w[0].toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+export function detectCurrentState(themes) {
+  const activeTheme = themes.find((t) => t.enabled);
+  if (activeTheme) {
+    return {
+      currentThemeId: activeTheme.id,
+      currentThemeName: activeTheme.name,
+      isDefault: false,
+    };
+  }
+  return {
+    currentThemeId: DEFAULT_ID,
+    currentThemeName: 'Default Theme',
+    isDefault: true,
+  };
+}

--- a/src/popupLogic.test.js
+++ b/src/popupLogic.test.js
@@ -1,0 +1,46 @@
+import { extractName, detectCurrentState, DEFAULT_ID } from './popupLogic.js';
+
+describe('extractName', () => {
+  test('extracts and formats a chrome web store theme name', () => {
+    const link =
+      'https://chromewebstore.google.com/detail/dark-theme/abcdefghijklmnop';
+    expect(extractName(link)).toBe('Dark Theme');
+  });
+
+  test('handles multi-word hyphenated names', () => {
+    const link =
+      'https://chromewebstore.google.com/detail/super-dark-theme/abcdefghijklmnop';
+    expect(extractName(link)).toBe('Super Dark Theme');
+  });
+});
+
+describe('detectCurrentState', () => {
+  test('returns active theme when one is enabled', () => {
+    const themes = [
+      { id: 'a', name: 'A', enabled: false },
+      { id: 'b', name: 'B', enabled: true },
+    ];
+    expect(detectCurrentState(themes)).toEqual({
+      currentThemeId: 'b',
+      currentThemeName: 'B',
+      isDefault: false,
+    });
+  });
+
+  test('returns default state when none are enabled', () => {
+    const themes = [{ id: 'a', name: 'A', enabled: false }];
+    expect(detectCurrentState(themes)).toEqual({
+      currentThemeId: DEFAULT_ID,
+      currentThemeName: 'Default Theme',
+      isDefault: true,
+    });
+  });
+
+  test('returns default state when list is empty', () => {
+    expect(detectCurrentState([])).toEqual({
+      currentThemeId: DEFAULT_ID,
+      currentThemeName: 'Default Theme',
+      isDefault: true,
+    });
+  });
+});


### PR DESCRIPTION
This PR refactors popup.js to improve testability and maintainability.

Changes:
- Extracted pure logic functions from popup.js into a new module: src/popupLogic.js
- Added Jest tests for popupLogic functions
- Updated popup.js to import the extracted logic
- Updated ESLint configuration to support Jest globals in test files

Benefits:
- Improves separation of UI logic and application logic
- Makes popup functionality easier to test
- Increases overall unit test coverage

Testing:
- Ran `npm run lint`
- Ran `npm test -- --coverage`
- Verified extension functionality manually in Chrome (popup opens, dropdown loads, themes toggle correctly)

All CI checks are passing.

Reviewer Testing Instructions

To verify the changes in this PR:

1. Checkout the branch
   git checkout develop
   git pull origin develop
   git checkout refactor/popup-logic-tests

2. Install dependencies (if needed)
   npm install

3. Run linting
   npm run lint

4. Run tests with coverage
   npm test -- --coverage

5. Manually test the extension in Chrome
   - Go to chrome://extensions
   - Enable "Developer Mode"
   - Click "Reload" on the extension
   - Open the extension popup

6. Verify functionality
   - Popup loads without errors
   - Dropdown displays stored themes correctly
   - Current theme indicator updates correctly
   - Selecting a theme applies/reverts themes as expected
   - Toggle button works
   - Add/Delete/Clear theme collection actions still function correctly

These changes should not alter extension behavior, only refactor logic for better testability.