### PR TITLE
Refactor toggle theme logic into testable module and add tests

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -15,6 +15,9 @@ import {
   detectCurrentState,
   DEFAULT_ID,
 } from './src/popupLogic.js';
+import {
+   getTogglePlan 
+} from './src/toggleThemeLogic.js';
 
 const STORAGE_KEY = 'themeState';
 
@@ -180,14 +183,15 @@ async function handleDropdownChange() {
 async function handleThemeToggle() {
   const themes = await getInstalledThemes();
 
-  const activeTheme = themes.find((t) => t.enabled);
-  const inactiveTheme = themes.find((t) => !t.enabled);
-
   try {
-    let newState;
+    const plan = getTogglePlan(themes);
 
-    if (activeTheme) {
-      chrome.management.setEnabled(activeTheme.id, false, () => {
+    if (!plan) {
+      return;
+    }
+
+    if (plan.action === 'disable') {
+      chrome.management.setEnabled(plan.themeId, false, () => {
         if (chrome.runtime.lastError) {
           console.error(chrome.runtime.lastError);
         } else {
@@ -195,33 +199,19 @@ async function handleThemeToggle() {
         }
       });
       revertTheme();
-
-      newState = {
-        currentThemeId: DEFAULT_ID,
-        currentThemeName: 'Default Theme',
-        isDefault: true,
-      };
-    } else if (inactiveTheme) {
-      chrome.management.setEnabled(inactiveTheme.id, true, () => {
+    } else if (plan.action === 'enable') {
+      chrome.management.setEnabled(plan.themeId, true, () => {
         if (chrome.runtime.lastError) {
           console.error(chrome.runtime.lastError);
         } else {
-          console.log('Extension disabled!');
+          console.log('Extension enabled!');
         }
       });
-      applyTheme(inactiveTheme.id);
-
-      newState = {
-        currentThemeId: inactiveTheme.id,
-        currentThemeName: inactiveTheme.name,
-        isDefault: false,
-      };
-    } else {
-      return;
+      applyTheme(plan.themeId);
     }
 
-    await saveState(newState);
-    renderCurrentThemeUI(newState);
+    await saveState(plan.newState);
+    renderCurrentThemeUI(plan.newState);
   } catch (err) {
     console.error('Theme toggle failed:', err);
     showNotice(`Failed to toggle theme: ${err.message}`);

--- a/src/toggleThemeLogic.js
+++ b/src/toggleThemeLogic.js
@@ -1,0 +1,32 @@
+import { DEFAULT_ID } from './popupLogic.js';
+
+export function getTogglePlan(themes) {
+  const activeTheme = themes.find((t) => t.enabled);
+  const inactiveTheme = themes.find((t) => !t.enabled);
+
+  if (activeTheme) {
+    return {
+      action: 'disable',
+      themeId: activeTheme.id,
+      newState: {
+        currentThemeId: DEFAULT_ID,
+        currentThemeName: 'Default Theme',
+        isDefault: true,
+      },
+    };
+  }
+
+  if (inactiveTheme) {
+    return {
+      action: 'enable',
+      themeId: inactiveTheme.id,
+      newState: {
+        currentThemeId: inactiveTheme.id,
+        currentThemeName: inactiveTheme.name,
+        isDefault: false,
+      },
+    };
+  }
+
+  return null;
+}

--- a/src/toggleThemeLogic.test.js
+++ b/src/toggleThemeLogic.test.js
@@ -1,0 +1,52 @@
+import { getTogglePlan } from './toggleThemeLogic.js';
+
+describe('getTogglePlan', () => {
+  test('returns disable plan when an active theme exists', () => {
+    const themes = [
+      { id: 'theme1', name: 'Dark Theme', enabled: true },
+      { id: 'theme2', name: 'Light Theme', enabled: false },
+    ];
+
+    expect(getTogglePlan(themes)).toEqual({
+      action: 'disable',
+      themeId: 'theme1',
+      newState: {
+        currentThemeId: 'default',
+        currentThemeName: 'Default Theme',
+        isDefault: true,
+      },
+    });
+  });
+
+  test('returns enable plan when no active theme exists but an inactive theme exists', () => {
+    const themes = [
+      { id: 'theme2', name: 'Light Theme', enabled: false },
+    ];
+
+    expect(getTogglePlan(themes)).toEqual({
+      action: 'enable',
+      themeId: 'theme2',
+      newState: {
+        currentThemeId: 'theme2',
+        currentThemeName: 'Light Theme',
+        isDefault: false,
+      },
+    });
+  });
+
+  test('returns null when no themes exist', () => {
+    expect(getTogglePlan([])).toBeNull();
+  });
+
+  test('prefers disabling the active theme when both active and inactive themes exist', () => {
+    const themes = [
+      { id: 'theme1', name: 'Dark Theme', enabled: true },
+      { id: 'theme2', name: 'Light Theme', enabled: false },
+    ];
+
+    const plan = getTogglePlan(themes);
+
+    expect(plan.action).toBe('disable');
+    expect(plan.themeId).toBe('theme1');
+  });
+});


### PR DESCRIPTION
Summary
This PR extracts theme toggle decision logic from popup.js into a separate module to improve testability.

Changes
- Added src/toggleThemeLogic.js to contain pure toggle decision logic
- Added src/toggleThemeLogic.test.js with Jest tests
- Updated popup.js to use the extracted toggle plan

Benefits
- Separates decision logic from Chrome API side effects
- Improves maintainability of popup.js
- Adds additional unit tests and improves coverage

Testing
- npm run lint
- npm test -- --coverage
- Verified all test suites pass locally

Note
This PR is based on the refactor/popup-logic-tests branch and should be merged after that PR.

Reviewer Testing Instructions

This PR builds on the refactor/popup-logic-tests branch.

Setup
1. Checkout the base branch and update:
   git checkout refactor/popup-logic-tests
   git pull origin refactor/popup-logic-tests

2. Checkout this branch:
   git checkout refactor/toggle-theme-logic

3. Install dependencies (if needed):
   npm install

Run Linting
4. Run ESLint:
   npm run lint

Run Tests
5. Run Jest tests with coverage:
   npm test -- --coverage
Note: This PR depends on refactor/popup-logic-tests and should be merged after that PR.

You should see all test suites passing.

Files Added
- src/toggleThemeLogic.js
- src/toggleThemeLogic.test.js

These tests verify the decision logic used by the theme toggle functionality.

Manual Extension Testing
6. Load the extension locally:
   - Open chrome://extensions
   - Enable Developer Mode
   - Click "Reload" on the extension

7. Verify behavior:
   - Popup loads normally
   - Toggle button correctly enables/disables themes
   - Current theme state updates correctly