### PR TITLE
Fixed NPM run build not including all relevant files

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,18 +1,19 @@
 // build.js
-import { promises as fs } from "node:fs";
-import path from "node:path";
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
 
-const DIST_DIR = "dist";
+const DIST_DIR = 'dist';
 
 // Add whatever your extension actually needs at runtime:
 const COPY_TARGETS = [
-  "manifest.json",
-  "popup.html",
-  "popup.js",
-  "icon.png",
-  "icons",        // folder (recommended)
-  "assets",       // folder (if you have one)
-  "styles",       // folder (if you have one)
+  'manifest.json',
+  'popup.html',
+  'popup.js',
+  'icon.png',
+  'src/popupLogic.js',
+  'src/themes.js',
+  'src/chromeThemes.js',
+  'src/ui.js',
 ];
 
 async function exists(p) {
@@ -61,13 +62,13 @@ async function main() {
     }
   }
 
-  console.log(`Build complete. Copied: ${copied.join(", ") || "(none)"}`);
+  console.log(`Build complete. Copied: ${copied.join(', ') || '(none)'}`);
   if (missing.length) {
-    console.log(`Note: Not found (skipped): ${missing.join(", ")}`);
+    console.log(`Note: Not found (skipped): ${missing.join(', ')}`);
   }
 }
 
 main().catch((err) => {
-  console.error("Build failed:", err);
+  console.error('Build failed:', err);
   process.exit(1);
 });

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "themanager",
-  "description": "Themanager manages your chrome themes so you can access them quickly and easily",
+  "name": "The Juggler",
+  "description": "The Juggler juggles your chrome themes so you can access them quickly and easily",
   "version": "0.01",
   "manifest_version": 3,
   "action": {


### PR DESCRIPTION
## This PR introduces the following changes:

Fixes the bug outlined in the title

## Steps for review

- Load the extension and test functionality to ensure it hasn't been broken
- In the command line, go to the directory of the project 
- run npm run build
- confirm it gives no errors
- check the dist folder and confirm all the required .js, html, and icon files are there